### PR TITLE
:aussieparrot:

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Hit the escape key to quit.
 
 You can limit your parrots enthusiasm with the `-loops` flag.
 
+### :fastparrot:
+
+Set the frame delay with the `-delay` flag (defaults to 75, use 25 for :fastparrot:)
+
+### :aussieparrot:
+
+Use `-orientation aussie` for our friends down under.
+
 ## Thanks
 
 Idea from seeing [this tweet from @rachsmithtweets](https://twitter.com/rachsmithtweets/status/742785722290212868)

--- a/draw.go
+++ b/draw.go
@@ -5,9 +5,22 @@ import "strings"
 
 var frame = 0
 
-func draw() {
+func reverse(lines []string) []string {
+	newLines := make([]string, len(lines))
+	for i, j := 0, len(lines)-1; i < j; i, j = i+1, j-1 {
+		newLines[i], newLines[j] = lines[j], lines[i]
+	}
+	return newLines
+}
+
+func draw(orientation string) {
 	termbox.Clear(termbox.ColorDefault, termbox.ColorDefault)
 	lines := strings.Split(frames[frame], "\n")
+
+	if orientation == "aussie" {
+		lines = reverse(lines)
+	}
+
 	for x, line := range lines {
 		for y, cell := range line {
 			termbox.SetCell(y, x, cell, colors[frame], termbox.ColorDefault)

--- a/draw.go
+++ b/draw.go
@@ -1,26 +1,17 @@
 package main
 
 import "github.com/nsf/termbox-go"
+import "strings"
 
 var frame = 0
 
 func draw() {
 	termbox.Clear(termbox.ColorDefault, termbox.ColorDefault)
-	chars := len(frames[frame])
-	x := 8
-	y := 1
-	for index := 0; index < chars; index++ {
-		if '\n' == frames[frame][index] {
-			y++
-			x = 8
-			continue
+	lines := strings.Split(frames[frame], "\n")
+	for x, line := range lines {
+		for y, cell := range line {
+			termbox.SetCell(y, x, cell, colors[frame], termbox.ColorDefault)
 		}
-		if ' ' == frames[frame][index] {
-			termbox.SetCell(x, y, rune(frames[frame][index]), termbox.ColorDefault, termbox.ColorDefault)
-		} else {
-			termbox.SetCell(x, y, rune(frames[frame][index]), colors[frame], termbox.ColorDefault)
-		}
-		x++
 	}
 
 	termbox.Flush()

--- a/parrot.go
+++ b/parrot.go
@@ -7,6 +7,7 @@ import "flag"
 func main() {
 	loops := flag.Int("loops", 0, "number of times to loop (default: infinite)")
 	delay := flag.Int("delay", 75, "frame delay in ms")
+	orientation := flag.String("orientation", "regular", "regular or aussie")
 	flag.Parse()
 
 	err := termbox.Init()
@@ -25,7 +26,7 @@ func main() {
 	termbox.SetOutputMode(termbox.Output256)
 
 	loop_index := 0
-	draw()
+	draw(*orientation)
 
 loop:
 	for {
@@ -39,7 +40,7 @@ loop:
 			if *loops > 0 && (loop_index/9) >= *loops {
 				break loop
 			}
-			draw()
+			draw(*orientation)
 			time.Sleep(time.Duration(*delay) * time.Millisecond)
 		}
 	}

--- a/parrot.go
+++ b/parrot.go
@@ -6,6 +6,7 @@ import "flag"
 
 func main() {
 	loops := flag.Int("loops", 0, "number of times to loop (default: infinite)")
+	delay := flag.Int("delay", 75, "frame delay in ms")
 	flag.Parse()
 
 	err := termbox.Init()
@@ -39,7 +40,7 @@ loop:
 				break loop
 			}
 			draw()
-			time.Sleep(75 * time.Millisecond)
+			time.Sleep(time.Duration(*delay) * time.Millisecond)
 		}
 	}
 }


### PR DESCRIPTION
This allows the command line option `-orientation [regular|aussie]`, as well as `-delay int (default 75)` (use 25 for :fastparrot:) plus some minor refactorings to make aussie easier