### PR TITLE
Improve parrot frames - colors match original gif

### DIFF
--- a/data.go
+++ b/data.go
@@ -119,7 +119,6 @@ KOc,l;''''''';lldkkkkkkkkkkkkkkkkkc..;lc.
 xx:':;;;;,.,,...,;;cllllllllllllllc;'.;oo,
 cNo.....................................oc`,
 
-
 `
 
                    .ccccccc.
@@ -198,14 +197,15 @@ cNd.........................................;lOc`,
 }
 
 var colors = [num_frames]termbox.Attribute{
-	termbox.Attribute(425),
-	termbox.Attribute(227),
-	termbox.Attribute(47),
-	termbox.Attribute(263),
-	termbox.ColorBlue,
-	termbox.Attribute(275),
-	termbox.Attribute(383),
-	termbox.Attribute(419),
-	termbox.Attribute(202),
-	termbox.Attribute(204),
+	// approx colors from original gif
+	termbox.Attribute(210),   // peach
+	termbox.Attribute(222),   // orange
+	termbox.Attribute(120),   // green
+	termbox.Attribute(123),   // cyan
+	termbox.Attribute(111),   // blue
+	termbox.Attribute(134),   // purple
+	termbox.Attribute(177),   // pink
+	termbox.Attribute(207),   // fuschia
+	termbox.Attribute(206),   // magenta
+	termbox.Attribute(204),   // red
 }

--- a/data.go
+++ b/data.go
@@ -118,25 +118,6 @@ xx:':;;;;,.,,...,;;cllllllllllllllc;'.;oo,
 cNo.....................................oc`,
 
 	`
-           .,,,,,,,,,.
-         .ckKxodooxOOdcc.
-      .cclooc'....';;cool.
-     .loc;;;;clllllc;;;;;:;,.
-   .c:'.,okd;;cdo:::::cl,..oc
-  .:o;';okkx;';;,';::;'....,;,.
-  co..ckkkkkddk:,cclll;.,c:,:o:.
-  co..ckkkkkkkk:,cllll;.:kkd,.':c.
-.,:;.,okkkkkkkk:,cclll;.:kkkdl;;o:.
-cNo..ckkkkkkkkko,.;llc,.ckkkkkc..oc
-,dd;.:kkkkkkkkkx;..;:,.'lkkkkko,.:,
-  ;c.ckkkkkkkkkkc.....;ldkkkkkk:.,'
-,dc..'okkkkkkkkkxoc;;cxkkkkkkkkc..,;,.
-kNo..':lllllldkkkkkkkkkkkkkkkkkdcc,.;l.
-KOc,l;''''''';lldkkkkkkkkkkkkkkkkkc..;lc.
-xx:':;;;;,.,,...,;;cllllllllllllllc;'.;oo,
-cNo.....................................oc`,
-
-	`
 
                    .ccccccc.
                .ccckNKOOOOkdcc.

--- a/data.go
+++ b/data.go
@@ -2,8 +2,10 @@ package main
 
 import "github.com/nsf/termbox-go"
 
-var frames = [...]string{
-	`                         .cccc;;cc;';c.
+const num_frames = 10
+
+var frames = [num_frames]string{
+`                        .cccc;;cc;';c.
                       .,:dkdc:;;:c:,:d:.
                      .loc'.,cc::::::,..,:.
                    .cl;....;dkdccc::,...c;
@@ -22,7 +24,7 @@ var frames = [...]string{
 ,dx:..;lllllllllllllllllllllllllllllllloc'...
 cNO;........................................`,
 
-	`                .ckx;'........':c.
+`                .ckx;'........':c.
              .,:c:c:::oxxocoo::::,',.
             .odc'..:lkkoolllllo;..;d,
             ;c..:o:..;:..',;'.......;.
@@ -41,7 +43,7 @@ cNO;........................................`,
 :0o...:dxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxo,.:,
 cNo........................................;'`,
 
-	`            .cc;.  ...  .;c.
+`            .cc;.  ...  .;c.
          .,,cc:cc:lxxxl:ccc:;,.
         .lo;...lKKklllookl..cO;
       .cl;.,;'.okl;...'.;,..';:.
@@ -60,7 +62,7 @@ cNo........................................;'`,
   co..:dddddddddddddddddddddddddddddddddl:;''::.
   co..........................................."`,
 
-	`           .ccccccc.
+`           .ccccccc.
       .,,,;cooolccol;;,,.
      .dOx;..;lllll;..;xOd.
    .cdo,',loOXXXXXkll;';odc.
@@ -79,7 +81,7 @@ cNo..lXXXXXXXXXOolkXXXXXXXXXkl;..;:.;.
   ';.:xxxxxocccoxxxxxxxxxxxxxxxxxxxxxxl::'.';;.
   ';........................................;l'`,
 
-	`
+`
         .;:;;,.,;;::,.
      .;':;........'co:.
    .clc;'':cllllc::,.':c.
@@ -98,7 +100,7 @@ o..,l;'''''';dkkkkkkkkkkkkkkkkkkkkdlc,..;lc.
 o..;lc;;;;;;,,;clllllllllllllllllllllc'..,:c.
 o..........................................;'`,
 
-	`
+`
            .,,,,,,,,,.
          .ckKxodooxOOdcc.
       .cclooc'....';;cool.
@@ -117,7 +119,8 @@ KOc,l;''''''';lldkkkkkkkkkkkkkkkkkc..;lc.
 xx:':;;;;,.,,...,;;cllllllllllllllc;'.;oo,
 cNo.....................................oc`,
 
-	`
+
+`
 
                    .ccccccc.
                .ccckNKOOOOkdcc.
@@ -136,7 +139,7 @@ cNo.....................................oc`,
 ,dl,.'cooc:::,....,::coooooooooooc'.c:
 cNo.................................oc`,
 
-	`
+`
 
 
                         .cccccccc.
@@ -155,7 +158,7 @@ cNo.................................oc`,
 ,do:'..,:llllll:;;;;;;,..,;:lllllllll;..oc
 cNo.....................................oc`,
 
-	`
+`
 
                               .ccccc.
                          .cc;'coooxkl;.
@@ -174,7 +177,7 @@ cNo.....................................oc`,
 occ'..',:cccccccccccc:;;;;;;;;:ccccccccc,.'c,
 Ol;......................................;l'`,
 
-	`
+`
                               ,ddoodd,
                          .cc' ,ooccoo,'cc.
                       .ccldo;....,,...;oxdc.
@@ -194,7 +197,7 @@ Ol;......................................;l'`,
 cNd.........................................;lOc`,
 }
 
-var colors = [...]termbox.Attribute{
+var colors = [num_frames]termbox.Attribute{
 	termbox.Attribute(425),
 	termbox.Attribute(227),
 	termbox.Attribute(47),

--- a/draw.go
+++ b/draw.go
@@ -29,7 +29,7 @@ func draw(orientation string) {
 
 	termbox.Flush()
 	frame_index++
-	if frame_index > 8 {
+	if frame_index == num_frames {
 		frame_index = 0
 	}
 }

--- a/draw.go
+++ b/draw.go
@@ -3,7 +3,7 @@ package main
 import "github.com/nsf/termbox-go"
 import "strings"
 
-var frame = 0
+var frame_index = 0
 
 func reverse(lines []string) []string {
 	newLines := make([]string, len(lines))
@@ -15,7 +15,7 @@ func reverse(lines []string) []string {
 
 func draw(orientation string) {
 	termbox.Clear(termbox.ColorDefault, termbox.ColorDefault)
-	lines := strings.Split(frames[frame], "\n")
+	lines := strings.Split(frames[frame_index], "\n")
 
 	if orientation == "aussie" {
 		lines = reverse(lines)
@@ -23,13 +23,13 @@ func draw(orientation string) {
 
 	for x, line := range lines {
 		for y, cell := range line {
-			termbox.SetCell(y, x, cell, colors[frame], termbox.ColorDefault)
+			termbox.SetCell(y, x, cell, colors[frame_index], termbox.ColorDefault)
 		}
 	}
 
 	termbox.Flush()
-	frame++
-	if frame > 8 {
-		frame = 0
+	frame_index++
+	if frame_index > 8 {
+		frame_index = 0
 	}
 }


### PR DESCRIPTION
Parrot now uses all 10 frames, with new colors to match the original.
reference: https://github.com/jmhobbs/cultofthepartyparrot.com/blob/master/parrots/hd/parrot.gif

For some reason, the previous color scheme was using several shades of gray.
color specification: https://github.com/nsf/termbox-go/blob/master/api.go#L440

Removed a duplicate parrot frame that caused an apparent rendering jitter.
Edited spacing for readability.