### PR TITLE
Handle both Unix (\n) and Windows (\r\n) line endings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ stage/
 
 # Source archive packed by `snapcraft cleanbuild` before pushing to the LXD container
 /*_source.tar.bz2
+
+# Ignore windows executable files
+*.exe

--- a/animation.go
+++ b/animation.go
@@ -23,7 +23,13 @@ func LoadFromFile(files fs.FS, path string) (*Animation, error) {
 }
 
 func LoadFromBytes(b []byte) (*Animation, error) {
-	frames := bytes.Split(b, []byte("!--FRAME--!\n"))
+	// Handle both Unix (\n) and Windows (\r\n) line endings
+	separator := []byte("!--FRAME--!\n")
+	if bytes.Contains(b, []byte("!--FRAME--!\r\n")) {
+		separator = []byte("!--FRAME--!\r\n")
+	}
+
+	frames := bytes.Split(b, separator)
 
 	if len(frames) <= 2 {
 		return nil, fmt.Errorf("no frames found")


### PR DESCRIPTION
Before this, there was an error that made it impossible to compile for Windows:
  panic: no frames found