### PR TITLE
Update README to use go install for binary installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Either grab a build on the [releases page](https://github.com/jmhobbs/terminal-parrot/releases) or clone and run...
 
 ```bash
-$ go get -u github.com/jmhobbs/terminal-parrot
+$ go install github.com/jmhobbs/terminal-parrot@latest
 $ terminal-parrot
 ```
 


### PR DESCRIPTION
The current README suggests using `go get` to install the binary. As of Go 1.17+, `go get` is no longer supported for installing executables outside of a module and throws an error.

This PR updates the installation instructions to use `go install github.com/jmhobbs/terminal-parrot@latest`, which is the current standard for installing Go binaries.